### PR TITLE
Eliminate copy in various ARM versions, not needed because shift of 2nd ...

### DIFF
--- a/ll.arm.eabi.s
+++ b/ll.arm.eabi.s
@@ -157,13 +157,12 @@ offset_length:
 	orr	r7,r0,r7,LSL #8	@ merge back into 16 bits
 				@ this has match_length and match_position
 
-@	mov	r7,r4		@ copy r4 to r7
 				@ no need to mask r7, as we do it
 				@ by default in output_loop
 
 	mov	r0,#(THRESHOLD+1)
 	add	r6,r0,r7,LSR #(P_BITS)
-				@ r6 = (r4 >> P_BITS) + THRESHOLD + 1
+				@ r6 = (r7 >> P_BITS) + THRESHOLD + 1
 				@                       (=match_length)
 
 output_loop:

--- a/ll.arm.oabi.s
+++ b/ll.arm.oabi.s
@@ -147,16 +147,15 @@ offset_length:
 	ldrb	r4,[r3],#+1	@ load a byte, increment pointer	
 				@ we can't load halfword as no unaligned loads on arm
 
-	orr	r4,r0,r4,LSL #8	@ merge back into 16 bits
+	orr	r7,r0,r4,LSL #8	@ merge back into 16 bits
 				@ this has match_length and match_position
 
-	mov	r7,r4		@ copy r4 to r7
 				@ no need to mask r7, as we do it
 				@ by default in output_loop
 
 	mov	r0,#(THRESHOLD+1)
-	add	r6,r0,r4,LSR #(P_BITS)
-				@ r6 = (r4 >> P_BITS) + THRESHOLD + 1
+	add	r6,r0,r7,LSR #(P_BITS)
+				@ r6 = (r7 >> P_BITS) + THRESHOLD + 1
 				@                       (=match_length)
 
 output_loop:

--- a/ll.arm64.s
+++ b/ll.arm64.s
@@ -307,15 +307,14 @@ discrete_char:
 
 
 offset_length:
-	ldrh	w4,[x3],#+2	// load an unagligned halfword, increment
+	ldrh	w7,[x3],#+2	// load an unagligned halfword, increment
 
-	mov	x7,x4		// copy x4 to x7
 				// no need to mask x7, as we do it
 				// by default in output_loop
 
 	mov	x0,#(THRESHOLD+1)
-	add	x6,x0,x4,LSR #(P_BITS)
-				// r6 = (r4 >> P_BITS) + THRESHOLD + 1
+	add	x6,x0,x7,LSR #(P_BITS)
+				// r6 = (r7 >> P_BITS) + THRESHOLD + 1
 				//                       (=match_length)
 
 output_loop:


### PR DESCRIPTION
...operand is non-destructive.

Saves 4 bytes in arm.oabi, arm64
Was already implemented in arm.eabi, but comment not updated and old code confusingly left commented.
Already implemented in thumb2, not possible in thumb.