### PR TITLE
calculate lzss code size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ all:	ll ll.$(ARCH) \
 	ll.$(ARCH).fakeproc \
 	$(THUMB) ansi_compress ./sstrip/sstrip \
 	ll.$(ARCH).stripped ll.$(ARCH).fakeproc.stripped \
-	ll.$(ARCH).dis ll.$(ARCH).output
+	ll.$(ARCH).dis ll.$(ARCH).output lzss_code_size
 
 sstrip_ll: ll ./sstrip/sstrip
 	./sstrip/sstrip ll
@@ -290,6 +290,9 @@ logo.inc:	   $(ANSI_TO_USE) ansi_compress
 
 logo.lzss:	   $(ANSI_TO_USE) ansi_compress
 		   ./ansi_compress $(ANSI_TO_USE)
+
+lzss_code_size: ll.$(ARCH).dis
+	perl calc_lzss_size.pl ll.$(ARCH).dis
 
 clean:
 	rm -f ll ll_c ll.$(ARCH) ll.$(SOURCE_ARCH) *.fakeproc *.stripped \

--- a/calc_lzss_size.pl
+++ b/calc_lzss_size.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/env perl
+
+while (<>){
+  /<(decompression_loop|done_logo)>/ and /^([0-9a-f]+) <([a-z_]+)>/ and $adr{$2}=hex $1;
+}
+
+$n=$adr{done_logo} - $adr{decompression_loop};
+print "lzss code size = $n\n";

--- a/calc_lzss_size.pl
+++ b/calc_lzss_size.pl
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 
 while (<>){
-  /<(decompression_loop|done_logo)>/ and /^([0-9a-f]+) <([a-z_]+)>/ and $adr{$2}=hex $1;
+  /^([0-9a-f]+) <([a-z_]+)>:$/ and $adr{$2}=hex $1;
 }
 
-$n=$adr{done_logo} - $adr{decompression_loop};
+$n = $adr{done_logo} - $adr{decompression_loop};
 print "lzss code size = $n\n";


### PR DESCRIPTION
A perl script to extract labels and their addresses from the .dis file.

Calculates and prints the size of the lzss decoder.
