### PR TITLE
Align text_buf, take advantage to use and mask &text_buf[R] ptr, not R.

### DIFF
--- a/ll.arm64.s
+++ b/ll.arm64.s
@@ -282,10 +282,10 @@ _start:
 # optimized some more by Vince Weaver
 
 	adr	x1,out_buffer	// x1 = buffer we are printing to
-	mov	x2,#(N-F)	// x2 = R (starts as N-F)
 	adr	x3,logo		// x3 = logo begin
 	adr	x8,logo_end	// x8 = logo end
-	adr	x9,text_buf	// x9 = text_buf
+	adr	x9,text_buf	// x9 = text_buf, guaranteed bottom N+1 bits are 0
+	add	x2,x9,#(N-F)	// x2 = &text_buf[R] (starts as N-F)
 
 decompression_loop:
 	ldrb	w5,[x3],#1	// load a byte, increment pointer
@@ -326,9 +326,8 @@ output_loop:
 
 store_byte:
 	strb	w4,[x1],#+1		// store a byte, increment pointer
-	strb	w4,[x9,x2]		// store a byte to text_buf[r]
-	add 	x2,x2,#1		// r++
-	and 	x2,x2,#(N-1)		// mask r with N-1
+	strb	w4,[x2],#+1		// store a byte to text_buf+r, increment pointer
+	bic 	x2,x2,#N		// clear any overflow
 
 	subs	x6,x6,#1		// decement count
 	b.ne 	output_loop		// repeat until k>j
@@ -678,13 +677,13 @@ one:	.ascii	"One \0"
 #	section .bss
 #============================================================================
 .bss
-.lcomm uname_info,(65*6)
-.lcomm sysinfo_buff,(64)
-.lcomm ascii_buffer,10
-.lcomm  text_buf, (N+F-1)
-
+.align (P_BITS+1)
+.lcomm  text_buf, N
 .lcomm	disk_buffer,4096	//// we cheat!!!!
 .lcomm	out_buffer,16384
+.lcomm uname_info,(65*6)
+.lcomm sysinfo_buff,(64)
+.lcomm ascii_buffer,32
 
 
 	# see /usr/src/linux/include/linux/kernel.h


### PR DESCRIPTION
Reorder .bss section and add .align to ensure text_buf has alignment of 2*N,
that is the bottom P_BITS+1 bits of its address are all zero, so an overflow
from the bottom N bits of a pointer into it is harmless. This is zero cost in
executable size.

Convert x2 from representing R to being &text_buf[R]. Allows using
post-increment instead of a separate add, saving 4 bytes.

This optimisation is perhaps a little hacky, but it's totally safe and legitimate.

Some other ISA's may be able to do the same trick, but it won't be profitable unless they have

- auto-increment addressing AND
    - a BIC instruction with 11+ bit literals OR
    - an AND instruction with full pointer size literals (which probably de-optimises for size anyway) 

On aarch64, a Bit Field Insert from the Zero Register would also work instead of the BIC. This is also  uncommon elsewhere in a single instruction.
